### PR TITLE
updated testing logic to compare DOM instead of regex

### DIFF
--- a/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-recursion-by-building-a-decimal-to-binary-converter/6464ad3c9b2e6cf58224cfa9.md
+++ b/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-recursion-by-building-a-decimal-to-binary-converter/6464ad3c9b2e6cf58224cfa9.md
@@ -16,10 +16,35 @@ Now, use `getElementById` to select the element with that attribute value, again
 You should use the `.getElementById()` method to target the element where the `id` attribute matches the value of `inputVal` for the current object.
 
 ```js
-assert.match(
-  String(showAnimation),
-  /setTimeout\s*\([\s\S]+document\.getElementById\s*\(\s*obj\.inputVal\s*\)|setTimeout\s*\([\s\S]+document\.getElementById\s*\(\s*obj\s*\[\s*('|"|`)\s*inputVal\s*\1\s*\]\s*\)/
-);
+
+// Test function to check if the binary result is updated in the DOM
+const testShowAnimation = () => {
+  const inputValue = 5;  // Test with input value 5 (you can change this for other tests)
+
+  // Simulate user input (set the value of the number input field)
+  numberInput.value = inputValue;
+
+  // Trigger the showAnimation function (this will animate and update the DOM)
+  showAnimation();
+
+  // Wait enough time for the animation and DOM update to complete
+  setTimeout(() => {
+    // Get the DOM element corresponding to the input value (e.g., id="5")
+    const binaryElement = document.getElementById(inputValue);
+
+    // Expected binary result
+    const binaryResult = decimalToBinary(inputValue);
+
+    // Test if the binary result is correctly displayed in the DOM
+    assert (binaryElement && binaryElement.innerText === binaryResult);
+  }, 2500);  // Adjust this timeout to wait for the animation (needs to be longer than showMsgDelay)
+};
+
+// Run the test
+testShowAnimation();
+
+
+
 ```
 
 # --seed--
@@ -239,6 +264,7 @@ const showAnimation = () => {
     }, obj.addElDelay);
 
     setTimeout(() => {
+      obj.msg = 
 --fcc-editable-region--
 
 --fcc-editable-region--


### PR DESCRIPTION
changes testing logic of steps 103/104

* just merging into Ariel's branch since we are working on this issue together, so not committing to freeCodeCamp's main branch yet

Previously, the testing logic was simply a regex expression. But, since there are many ways to use `getElementbyId`, the proposed/triaged solution was to change the testing logic to compare the DOMs instead. So, I wrote a helper function testShowAnimation that does just that within the file for step 103: `freeCodeCamp/curriculum/challenges/english/15-javascript-algorithms-and-data-structures-22/learn-recursion-by-building-a-decimal-to-binary-converter/6464ad3c9b2e6cf58224cfa9.md`

Testing: since this step goes hand in hand with the 103/104 step merger, we will do testing on that level